### PR TITLE
Enhance `FirehoseTableSchema` and `ValueRow` with iterators, formatti…

### DIFF
--- a/crates/bimm-firehose/src/core/schema.rs
+++ b/crates/bimm-firehose/src/core/schema.rs
@@ -371,6 +371,16 @@ impl IndexMut<&str> for FirehoseTableSchema {
 }
 
 impl FirehoseTableSchema {
+    /// Returns an iterator over the columns in the schema.
+    pub fn iter(&self) -> impl Iterator<Item = &ColumnSchema> {
+        self.columns.iter()
+    }
+
+    /// Returns an iterator over the names of the columns in the schema.
+    pub fn names_iter(&self) -> impl Iterator<Item = &str> {
+        self.iter().map(|c| c.name.as_str())
+    }
+
     /// Gets a reference to a column by its name.
     pub fn get_column(
         &self,


### PR DESCRIPTION
…ng refinements, and new row creation.

- Added `iter` and `names_iter` to `FirehoseTableSchema` for schema-based iteration.
- Refined `Debug` formatting in `ValueRow` and `ValueRowBatch` for improved readability.
- Introduced a `new_row` method in `ValueRowBatch` to create rows with default slots.
- Simplified `ValueRow::iter` using `names_iter` and adjusted related tests.