### PR TITLE
Refactor image loader: streamline resize logic, update `FirehoseRow` …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ version = "0.2.0"
 repository = "https://github.com/crutcher/bimm"
 license = "MIT"
 
+[workspace.lints.rust]
+warnings = "deny"
+
 [workspace.lints.clippy]
 double_must_use = "allow"
 doc_markdown = "warn"

--- a/crates/bimm-firehose/src/core/rows.rs
+++ b/crates/bimm-firehose/src/core/rows.rs
@@ -448,7 +448,7 @@ impl FirehoseRowBatch {
     pub fn drain_rows<R>(
         &mut self,
         range: R,
-    ) -> Drain<FirehoseRow>
+    ) -> Drain<'_, FirehoseRow>
     where
         R: RangeBounds<usize>,
     {

--- a/crates/bimm-firehose/src/ops/image/loader.rs
+++ b/crates/bimm-firehose/src/ops/image/loader.rs
@@ -158,10 +158,10 @@ impl FirehoseOperator for ImageLoader {
         let mut image = image::open(path.clone())
             .with_context(|| format!("Failed to load image from path: {path}"))?;
 
-        if let Some(spec) = &self.resize {
-            if image.width() != spec.shape.width || image.height() != spec.shape.height {
-                image = image.resize_exact(spec.shape.width, spec.shape.height, spec.filter);
-            }
+        if let Some(spec) = &self.resize
+            && (image.width() != spec.shape.width || image.height() != spec.shape.height)
+        {
+            image = image.resize_exact(spec.shape.width, spec.shape.height, spec.filter);
         }
 
         if let Some(color) = &self.recolor {


### PR DESCRIPTION
…drain return type, and enforce stricter lint settings in workspace.