### PR TITLE
Add speckle noise augmentation stage and update `swin_tiny` pipeline

### DIFF
--- a/crates/bimm-firehose/src/ops/image/augmentation/noise/mod.rs
+++ b/crates/bimm-firehose/src/ops/image/augmentation/noise/mod.rs
@@ -1,2 +1,4 @@
 /// Image blur stages.
 pub mod blur;
+/// Image speckle noise stages.
+pub mod speckle;

--- a/crates/bimm-firehose/src/ops/image/augmentation/noise/speckle.rs
+++ b/crates/bimm-firehose/src/ops/image/augmentation/noise/speckle.rs
@@ -1,0 +1,75 @@
+use crate::define_image_aug_plugin;
+use crate::ops::image::augmentation::{
+    AugmentationStage, AugmentationStageConfig, ImageAugContext, PluginBuilder,
+    WithAugmentationStageBuilder,
+};
+use image::{DynamicImage, GenericImage, GenericImageView};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::Arc;
+
+define_image_aug_plugin!(SPECKLE, SpeckleStage::build_stage);
+
+/// A stage of speckle noise augmentation.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum SpeckleStage {
+    /// Uniform speckle noise.
+    Uniform {
+        /// The pixel density of the speckles.
+        density: f32,
+    },
+}
+
+impl Default for SpeckleStage {
+    fn default() -> Self {
+        Self::Uniform {
+            density: 1.0 / 100.0,
+        }
+    }
+}
+
+impl WithAugmentationStageBuilder for SpeckleStage {
+    fn build_stage(
+        config: &AugmentationStageConfig,
+        _builder: &dyn PluginBuilder,
+    ) -> anyhow::Result<Arc<dyn AugmentationStage>> {
+        Ok(Arc::new(serde_json::from_value::<SpeckleStage>(
+            config.body.clone(),
+        )?))
+    }
+}
+
+impl AugmentationStage for SpeckleStage {
+    fn name(&self) -> &str {
+        SPECKLE
+    }
+
+    fn as_config_body(&self) -> Value {
+        serde_json::to_value(self).unwrap()
+    }
+
+    fn augment_image(
+        &self,
+        image: DynamicImage,
+        _ctx: &mut ImageAugContext,
+    ) -> anyhow::Result<DynamicImage> {
+        Ok(match self {
+            SpeckleStage::Uniform { density } => {
+                let mut image = image.clone();
+
+                let (w, h) = image.dimensions();
+                let speckle_count = (((h * w) as f32) * *density) as usize;
+
+                for _ in 0..speckle_count {
+                    let a = (w as f32 * rand::random::<f32>()) as u32;
+                    let b = (h as f32 * rand::random::<f32>()) as u32;
+                    let x = (w as f32 * rand::random::<f32>()) as u32;
+                    let y = (h as f32 * rand::random::<f32>()) as u32;
+                    image.put_pixel(x, y, image.get_pixel(a, b));
+                }
+
+                image
+            }
+        })
+    }
+}

--- a/examples/swin_tiny/src/main.rs
+++ b/examples/swin_tiny/src/main.rs
@@ -16,6 +16,7 @@ use bimm_firehose::ops::image::augmentation::AugmentImageOperation;
 use bimm_firehose::ops::image::augmentation::control::choose_one::ChooseOneStage;
 use bimm_firehose::ops::image::augmentation::control::with_prob::WithProbStage;
 use bimm_firehose::ops::image::augmentation::noise::blur::BlurStage;
+use bimm_firehose::ops::image::augmentation::noise::speckle::SpeckleStage;
 use bimm_firehose::ops::image::augmentation::orientation::flip::HorizontalFlipStage;
 use bimm_firehose::ops::image::burn::{ImageToTensorData, stack_tensor_data_column};
 use bimm_firehose::ops::image::loader::{ImageLoader, ResizeSpec};
@@ -26,7 +27,7 @@ use burn::config::Config;
 use burn::data::dataloader::{DataLoaderBuilder, Dataset};
 use burn::data::dataset::transform::{ComposedDataset, SamplerDataset, ShuffledDataset};
 use burn::grad_clipping::GradientClippingConfig;
-use burn::lr_scheduler::cosine::CosineAnnealingLrSchedulerConfig;
+use burn::lr_scheduler::exponential::ExponentialLrSchedulerConfig;
 use burn::module::Module;
 use burn::nn::loss::CrossEntropyLossConfig;
 use burn::optim::AdamWConfig;
@@ -65,7 +66,7 @@ pub struct Args {
     seed: u64,
 
     /// Batch size for processing
-    #[arg(short, long, default_value_t = 512)]
+    #[arg(short, long, default_value_t = 1024)]
     batch_size: usize,
 
     /// Number of workers for data loading.
@@ -75,13 +76,6 @@ pub struct Args {
     /// Number of epochs to train the model.
     #[arg(long, default_value = "60")]
     num_epochs: usize,
-
-    // /// Number of epochs to warm-up the model.
-    // #[arg(long, default_value = "4")]
-    // num_warmup_epochs: usize,
-    /// Number of epochs between restarts.
-    #[arg(long, default_value = "3.5")]
-    restart_epochs: f64,
 
     /// Embedding ratio: ``ratio * channels * patch_size * patch_size``
     #[arg(long, default_value = "0.75")]
@@ -95,9 +89,9 @@ pub struct Args {
     #[arg(long, default_value = "1.0e-3")]
     learning_rate: f64,
 
-    /// Min learning rate for the optimizer.
-    #[arg(long, default_value = "1.0e-5")]
-    min_learning_rate: f64,
+    /// Learning rate decay gamma.
+    #[arg(long, default_value = "0.999")]
+    lr_gamma: f64,
 
     /// Directory to save the artifacts.
     #[arg(long, default_value = "/tmp/swin_tiny_cinic10")]
@@ -161,7 +155,7 @@ pub fn backend_main<B: AutodiffBackend>(
     let training_config = TrainingConfig::new(
         ModelConfig { swin: swin_config },
         AdamWConfig::new()
-            .with_weight_decay(0.05)
+            // .with_weight_decay(0.01)
             .with_grad_clipping(Some(GradientClippingConfig::Norm(5.0))),
     );
 
@@ -196,8 +190,6 @@ pub fn backend_main<B: AutodiffBackend>(
         schema
     };
 
-    let num_batches: usize;
-
     let train_dataloader = {
         let ds = ComposedDataset::new(vec![
             CinicDataset {
@@ -211,8 +203,6 @@ pub fn backend_main<B: AutodiffBackend>(
         let num_samples = (args.oversample_ratio * (ds.len() as f64)).ceil() as usize;
         let ds = SamplerDataset::with_replacement(ds, num_samples);
 
-        num_batches = ds.len() / args.batch_size;
-
         let schema = Arc::new({
             let mut schema = common_schema.clone();
 
@@ -221,6 +211,9 @@ pub fn backend_main<B: AutodiffBackend>(
                     0.5,
                     Arc::new(HorizontalFlipStage::new()),
                 )),
+                Arc::new(SpeckleStage::Uniform {
+                    density: 1.0 / 32.0,
+                }),
                 Arc::new(
                     ChooseOneStage::new()
                         .with_choice(1.0, Arc::new(BlurStage::Gaussian { sigma: 0.25 }))
@@ -290,9 +283,7 @@ pub fn backend_main<B: AutodiffBackend>(
         builder.build(ds)
     };
 
-    let num_iters = (args.restart_epochs * (num_batches as f64)) as usize;
-    let lr_scheduler = CosineAnnealingLrSchedulerConfig::new(args.learning_rate, num_iters)
-        .with_min_lr(args.min_learning_rate)
+    let lr_scheduler = ExponentialLrSchedulerConfig::new(args.learning_rate, args.lr_gamma)
         .init()
         .map_err(|e| anyhow::anyhow!("Failed to initialize learning rate scheduler: {}", e))?;
 


### PR DESCRIPTION
- Introduced `SpeckleStage` for speckle noise augmentation with configurable density.
- Integrated `SpeckleStage` into `swin_tiny` example's augmentation schema.
- Replaced learning rate scheduler with exponential decay and updated training arguments.