### PR TITLE
docs: standardize argument section headers in documentation

### DIFF
--- a/crates/bimm-firehose-image/src/augmentation/mod.rs
+++ b/crates/bimm-firehose-image/src/augmentation/mod.rs
@@ -33,7 +33,7 @@ macro_rules! define_image_aug_plugin {
 
 /// Registers a [`AugmentationStage`].
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// - `name`: the local reference name of the plugin ID;
 ///   used by `define_image_aug_plugin!()`.
@@ -158,12 +158,12 @@ pub trait AugmentationStage: Debug + Send + Sync {
 
     /// Apply the stage to the image.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `image`: the image to augment.
     /// - `ctx`: the `AugmentationContex` being operated in.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A (modified?) image.
     fn augment_image(
@@ -194,7 +194,7 @@ pub struct AugmentImageConfig {
 impl AugmentImageConfig {
     /// Converts into an `OperationPlanner`
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `seed_column`: The name of the input column containing the augmentation seed.
     /// * `source_column`: The name of the input image column.
@@ -295,7 +295,7 @@ impl AugmentImageOperation {
 
     /// Converts into an `OperationPlanner`
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `seed_column`: The name of the input column containing the augmentation seed.
     /// * `source_column`: The name of the input image column.

--- a/crates/bimm-firehose-image/src/loader.rs
+++ b/crates/bimm-firehose-image/src/loader.rs
@@ -94,11 +94,11 @@ impl ImageLoader {
 
     /// Extends the `ImageLoader` with a resize specification.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `resize`: The resize specification to apply to the image.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `ImageLoader` instance with the specified resize applied.
     pub fn with_resize(
@@ -113,11 +113,11 @@ impl ImageLoader {
 
     /// Extends the `ImageLoader` with a recolor specification.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `recolor`: The color type to convert the image to.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `ImageLoader` instance with the specified recolor applied.
     pub fn with_recolor(
@@ -132,7 +132,7 @@ impl ImageLoader {
 
     /// Converts this `ImageLoader` configuration into an `OperationPlanner`
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `path_column`: The name of the input column containing the image file paths.
     /// * `image_column`: The name of the output column where the loaded images will be stored.

--- a/crates/bimm-firehose/src/core/identifiers.rs
+++ b/crates/bimm-firehose/src/core/identifiers.rs
@@ -12,11 +12,11 @@ pub fn ident_regex() -> &'static Regex {
 
 /// Checks if a string is a valid identifier.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// - `s`: The string to check.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// `true` if the string is a valid identifier, `false` otherwise.
 pub fn is_ident(s: &str) -> bool {
@@ -25,11 +25,11 @@ pub fn is_ident(s: &str) -> bool {
 
 /// Checks if a string is a valid identifier.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// - `s`: The string to check.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// Results in:
 /// - `Ok(())` if the string is a valid identifier,
@@ -52,11 +52,11 @@ pub fn path_ident_regex() -> &'static Regex {
 
 /// Parses a path identifier into its components.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// - `ident`: The path identifier string to parse.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// - `Ok(Vec<String>)` containing the components of the path identifier,
 /// - `Err(String)` if the identifier is invalid.

--- a/crates/bimm-firehose/src/core/operations/mod.rs
+++ b/crates/bimm-firehose/src/core/operations/mod.rs
@@ -15,7 +15,7 @@ pub mod signature;
 
 /// Combined macro to define and register a firehose operator.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// * `$name`: The name of the operator ID to define;
 ///   will create a self-referential static string constant.
@@ -35,7 +35,7 @@ macro_rules! define_firehose_operator {
 ///
 /// The id will be defined as a static string constant that refers to its own namespace path.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// * `$name`: The name of the operator ID to define.
 ///

--- a/crates/bimm-firehose/src/core/operations/signature.rs
+++ b/crates/bimm-firehose/src/core/operations/signature.rs
@@ -23,12 +23,12 @@ impl ParameterSpec {
     ///
     /// The type `T` is used to infer the data type of the parameter.
     ///
-    /// ## Parameters
+    /// # Parameters
     ///
     /// - `name`: The name of the parameter.
     /// - `T`: The type of the parameter, which is used to determine the data type description.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `ParameterSpec` instance with the specified name, data type, and required arity.
     pub fn new<T>(name: &str) -> Self {
@@ -139,13 +139,13 @@ impl FirehoseOperatorSignature {
 
     /// Internal helper to add a parameter specification to the list of inputs or outputs.
     ///
-    /// ## Parameters
+    /// # Parameters
     ///
     /// * `spec`: The parameter specification to add.
     /// * `ptype`: A string indicating the type of parameter ("input" or "output").
     /// * `specs`: The current list of parameter specifications (either inputs or outputs).
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `anyhow::Result<Vec<ParameterSpec>>` containing a new vector of parameter specifications with the added parameter.
     fn with_parameter(
@@ -169,11 +169,11 @@ impl FirehoseOperatorSignature {
 
     /// Extends the operator specification with an input parameter.
     ///
-    /// ## Parameters
+    /// # Parameters
     ///
     /// * `spec`: The input parameter specification to add.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `Result<Self, String>` where:
     /// * `Ok(Self)`: A new `FirehoseOperatorSignature` with the input parameter added.
@@ -192,15 +192,15 @@ impl FirehoseOperatorSignature {
 
     /// Extends the operator specification with an input parameter.
     ///
-    /// ## Parameters
+    /// # Parameters
     ///
     /// * `spec`: The input parameter specification to add.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `FirehoseOperatorSignature` with the input parameter added.
     ///
-    /// ## Panics
+    /// # Panics
     ///
     /// If the input parameter name already exists in the signature,
     pub fn with_input(
@@ -215,11 +215,11 @@ impl FirehoseOperatorSignature {
 
     /// Extends the operator specification with an output parameter.
     ///
-    /// ## Parameters
+    /// # Parameters
     ///
     /// * `spec`: The output parameter specification to add.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `Result<Self, String>` where:
     /// * `Ok(Self)`: A new `FirehoseOperatorSignature` with the output parameter added.
@@ -238,15 +238,15 @@ impl FirehoseOperatorSignature {
 
     /// Extends the operator specification with an output parameter.
     ///
-    /// ## Parameters
+    /// # Parameters
     ///
     /// * `spec`: The output parameter specification to add.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `FirehoseOperatorSignature` with the output parameter added.
     ///
-    /// ## Panics
+    /// # Panics
     ///
     /// If the output parameter name already exists in the signature,
     /// it will panic with an error message.

--- a/crates/bimm-firehose/src/core/rows.rs
+++ b/crates/bimm-firehose/src/core/rows.rs
@@ -131,11 +131,11 @@ pub trait FirehoseRowReader {
 
     /// Gets the column.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `column_name`: the name of the column.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `anyhow::Result<&FirehoseValue>` reference to the column value; or an error.
     fn try_get(
@@ -148,15 +148,15 @@ pub trait FirehoseRowReader {
 
     /// Gets the column.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `column_name`: the name of the column.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A reference to the column.
     ///
-    /// ## Panics
+    /// # Panics
     ///
     /// If the column is absent.
     fn expect_get(

--- a/crates/bimm-firehose/src/core/schema.rs
+++ b/crates/bimm-firehose/src/core/schema.rs
@@ -71,11 +71,11 @@ impl BuildPlan {
 
     /// Extends the build plan with a description.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `description`: The description to attach to the build plan.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `ColumnBuildPlan` with the description attached.
     pub fn with_description(
@@ -90,11 +90,11 @@ impl BuildPlan {
 
     /// Extends the build plan with a configuration.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `config`: The configuration to attach to the build plan, serialized as JSON.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `ColumnBuildPlan` with the configuration attached.
     pub fn with_config<T>(
@@ -112,11 +112,11 @@ impl BuildPlan {
 
     /// Builds a name map from a slice of tuples.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `assoc`: A slice of tuples where each tuple contains a parameter name and a column name.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A `BTreeMap<String, String>` mapping parameter names to column names.
     fn build_name_map(assoc: &[(&str, &str)]) -> BTreeMap<String, String> {
@@ -131,11 +131,11 @@ impl BuildPlan {
 
     /// Extends the build plan with input columns.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `inputs`: A slice of tuples where each tuple contains a parameter name and a column name.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `ColumnBuildPlan` with the input columns attached.
     pub fn with_inputs(
@@ -150,11 +150,11 @@ impl BuildPlan {
 
     /// Extends the build plan with output columns.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `outputs`: A slice of tuples where each tuple contains a parameter name and a column name.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `ColumnBuildPlan` with the output columns attached.
     pub fn with_outputs(
@@ -188,11 +188,11 @@ impl BuildPlan {
 
     /// Translates an input parameter name to its corresponding column name.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `parameter_name`: The name of the input parameter to translate.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `anyhow::Result<&str>` containing the column name corresponding to the input parameter.
     pub fn translate_input_name(
@@ -204,11 +204,11 @@ impl BuildPlan {
 
     /// Translates an output parameter name to its corresponding column name.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `parameter_name`: The name of the output parameter to translate.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `anyhow::Result<&str>` containing the column name corresponding to the output parameter.
     pub fn translate_output_name(
@@ -255,11 +255,11 @@ impl ColumnSchema {
 
     /// Extends the schema with a description.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `description`: The description to attach to the column.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `BimmColumnSchema` with the description attached.
     pub fn with_description(
@@ -376,12 +376,12 @@ impl FirehoseTableSchema {
     /// This function verifies the dependencies between build plans
     /// and ensures that all columns can be built in a valid order.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `columns`: A slice of `ColumnSchema` representing the columns in the table.
     /// - `plans`: A slice of `BuildPlan` representing the build plans for the table.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `anyhow::Result<(Vec<String>, Vec<BuildPlan>)>` containing the base columns and the ordered build plans.
     fn check_graph(
@@ -455,7 +455,7 @@ impl FirehoseTableSchema {
     ///
     /// This function checks the build plans and their dependencies to determine the order in which they should be executed.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `anyhow::Result<(Vec<String>, Vec<BuildPlan>)>` containing the base columns and the ordered build plans.
     pub fn build_order(&self) -> anyhow::Result<(Vec<String>, Vec<BuildPlan>)> {
@@ -479,7 +479,7 @@ impl FirehoseTableSchema {
 
     /// Checks if a column name is invalid, or conflicts with existing columns.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `name`: The name of the column to check.
     fn check_name(
@@ -540,12 +540,12 @@ impl FirehoseTableSchema {
 
     /// Adds a build plan and its output columns to the table description.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `plan`: The build plan to add.
     /// - `output_info`: A slice of tuples where each tuple contains the output column name, its data type, and a description.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `anyhow::Result<()>` indicating success or containing an error if the operation fails.
     pub fn add_build_plan_and_outputs(
@@ -569,12 +569,12 @@ impl FirehoseTableSchema {
 
     /// Extends the table schema with a build plan and its output columns.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `plan`: The build plan to extend the schema with.
     /// - `output_columns`: A map of output column names to their schemas.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `anyhow::Result<()>` indicating success or containing an error if the operation fails.
     pub fn extend_via_plan(
@@ -646,11 +646,11 @@ impl FirehoseTableSchema {
 
     /// Returns the index of a column by its name.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `name`: The name of the column to find.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `Option<usize>` containing the index of the column if found, or `None` if not found.
     pub fn column_index(
@@ -667,11 +667,11 @@ impl FirehoseTableSchema {
 
     /// Checks if a column with the given name exists and returns its index.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `name`: The name of the column to check.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `anyhow::Result<usize>` containing the index of the column if it exists.
     pub fn check_column_index(

--- a/crates/bimm-firehose/src/lib.rs
+++ b/crates/bimm-firehose/src/lib.rs
@@ -20,12 +20,12 @@ mod pipeline;
 ///
 /// The id will be defined as a static string constant that refers to its own namespace path.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// * `$name`: The final path name of the ID to define;
 ///   the rest of the name will be taken from the module context.
 ///
-/// ## Example
+/// # Example
 /// ```
 /// // In module "foo::bar"
 /// bimm_firehose::define_self_referential_id!(ID);

--- a/crates/bimm-firehose/src/pipeline/data_load_operator.rs
+++ b/crates/bimm-firehose/src/pipeline/data_load_operator.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 
 /// Support super-trait for loadable data types.
 ///
-/// ## Trait Requirements
+/// # Trait Requirements
 ///
 /// - `Debug`: the data item must be debuggable.
 /// - `Clone`: the data item must be cloneable.

--- a/crates/bimm-firehose/src/pipeline/data_load_schedule.rs
+++ b/crates/bimm-firehose/src/pipeline/data_load_schedule.rs
@@ -7,7 +7,7 @@ use std::hash::Hash;
 /// The type `M` must implement the `ScheduleItem` trait, which requires it to be
 /// Debug, Serialize, Sync, and Send safe.
 ///
-/// ## Motivation
+/// # Motivation
 ///
 /// This structure is designed to hold the intermediate schedule for a data pipeline
 /// load operation; in a format which can be serialized and deserialized;
@@ -32,7 +32,7 @@ where
 /// blanket implementations of `ScheduleItem` are provided for any type that meets
 /// the requirements.
 ///
-/// ## Trait Requirements
+/// # Trait Requirements
 ///
 /// - `Debug`: the schedule must be displayable.
 /// - `Clone`: the schedule must be cloneable.
@@ -93,11 +93,11 @@ where
 
     /// Filters the items in the schedule based on a provided filter function.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `predicate`: A closure that takes a reference to an item of type `M` and returns a boolean.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `DataLoadSchedule<M>` containing only the items that match the predicate.
     pub fn filter<P>(
@@ -123,11 +123,11 @@ where
     ///
     /// This function is useful for transforming the schedule items while filtering them.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `predicate`: A closure that takes a reference to an item of type `M` and returns an `Option<R>`.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `DataLoadSchedule<R>` containing the items that matched the predicate and were transformed to type `R`.
     pub fn filter_map<P, R>(

--- a/crates/bimm-firehose/src/utility/probability.rs
+++ b/crates/bimm-firehose/src/utility/probability.rs
@@ -4,11 +4,11 @@ use std::fmt::Debug;
 
 /// Validate a probability in the range ``[0.0, 1.0]``.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// - `prob`: the prob to check.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// An `anyhow::Result<prob>`
 pub fn try_probability<F: Float + Debug>(prob: F) -> anyhow::Result<F> {
@@ -20,15 +20,15 @@ pub fn try_probability<F: Float + Debug>(prob: F) -> anyhow::Result<F> {
 
 /// Expect a probability to be in range ``[0.0, 1.0]``, or panic.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// - `prob`: the prob to check.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// `prob`.
 ///
-/// ## Panics
+/// # Panics
 ///
 /// On range error.
 pub fn expect_probability<F: Float + Debug>(prob: F) -> F {

--- a/crates/bimm/src/layers/drop/drop_block.rs
+++ b/crates/bimm/src/layers/drop/drop_block.rs
@@ -173,7 +173,7 @@ impl DropBlockOptions {
     /// Gamma is the adjusted probability that any given point is the midpoint
     /// of a dropped block; given the desired `drop_rate`, the block size, and the input size.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `shape`: the shape of the target tensor.
     #[inline]

--- a/crates/bimm/src/layers/drop/drop_path.rs
+++ b/crates/bimm/src/layers/drop/drop_path.rs
@@ -16,14 +16,14 @@ use burn::tensor::Distribution;
 
 /// `DropPath` (stochastic depth) regularization.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// * `x`: Input tensor.
 /// * `drop_prob`: Probability of dropping a path.
 /// * `training`: Whether the model is in training mode.
 /// * `scale_by_keep`: Whether to scale the output by `1 / (1 - drop_prob)`
 ///
-/// ## Returns
+/// # Returns
 ///
 /// * Output tensor with the same shape as the input tensor.
 #[must_use]
@@ -48,7 +48,7 @@ pub fn drop_path<B: Backend, const D: usize>(
 ///
 /// Deferred to a separate function to allow for testing sampling.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// * `x`: Input tensor.
 /// * `drop_prob`: Probability of dropping a path.
@@ -56,7 +56,7 @@ pub fn drop_path<B: Backend, const D: usize>(
 /// * `scale_by_keep`: Whether to scale the output by `1 / (1 - drop_prob)`
 /// * `sample`: Sampling function to generate the random tensor.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// * Output tensor with the same shape as the input tensor.
 #[inline(always)]
@@ -175,12 +175,12 @@ impl DropPath {
     ///
     /// This is used for stochastic depth in the transformer block.
     ///
-    /// ## Parameters
+    /// # Parameters
     ///
     /// * `x` - Input tensor of shape (B, D).
     /// * `f` - Function to apply on the input tensor.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// The result of the function application, with a stochastic skip connection applied.
     #[inline]

--- a/crates/bimm/src/layers/patching/patch_embed.rs
+++ b/crates/bimm/src/layers/patching/patch_embed.rs
@@ -98,11 +98,11 @@ impl PatchEmbedMeta for PatchEmbedConfig {
 impl PatchEmbedConfig {
     /// Initialize a `PatchEmbed` module with the given configuration.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `device` - The device on which the module will be initialized.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// * A `PatchEmbed` module configured with the specified parameters.
     #[must_use]
@@ -174,13 +174,13 @@ impl<B: Backend> PatchEmbedMeta for PatchEmbed<B> {
 impl<B: Backend> PatchEmbed<B> {
     /// Apply the `PatchEmbed` module to an input tensor.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
-    /// * `x` - Input tensor of shape ``(B, C, H, W)``.
+    /// * `x` - Input tensor of shape ``[B, C, H, W]``.
     ///
-    /// ## Returns
+    /// # Returns
     ///
-    /// * Output tensor of shape ``(B, H/patch_size * W/patch_size, d_output)``.
+    /// * Output tensor of shape ``[B, H/patch_size * W/patch_size, d_output]``.
     #[must_use]
     pub fn forward(
         &self,

--- a/crates/bimm/src/models/swin/v2/block_sequence.rs
+++ b/crates/bimm/src/models/swin/v2/block_sequence.rs
@@ -268,11 +268,15 @@ impl<B: Backend> StochasticDepthTransformerBlockSequence<B> {
     ///
     /// # Arguments
     ///
-    /// - `x`: Input tensor of shape (B, H * W, C).
+    /// - `x`: Input tensor of shape: ``[batch, height * width, channels]``.
     ///
     /// # Returns
     ///
-    /// Output tensor of shape (B, H * W, C).
+    /// Output tensor of shape ``[batch, height * width, channels``.
+    ///
+    /// # Panics
+    ///
+    /// If the input tensor fails the shape contract.
     #[must_use]
     pub fn forward(
         &self,

--- a/crates/bimm/src/models/swin/v2/swin_block.rs
+++ b/crates/bimm/src/models/swin/v2/swin_block.rs
@@ -63,11 +63,11 @@ impl BlockMlpMeta for BlockMlpConfig {
 impl BlockMlpConfig {
     /// Creates a new `BlockMlp`.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// - `device`: The device on which the MLP will be initialized.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A new `BlockMlp` instance.
     pub fn init<B: Backend>(
@@ -123,6 +123,14 @@ impl<B: Backend> BlockMlpMeta for BlockMlp<B> {
 
 impl<B: Backend> BlockMlp<B> {
     /// Apply the MLP to the input tensor.
+    ///
+    /// # Arguments
+    ///
+    /// - `x`: a tensor of ``[batch = ..., in]``.
+    ///
+    /// # Returns
+    ///
+    /// A tensor of ``[batch = ... out]``
     #[must_use]
     pub fn forward<const D: usize>(
         &self,
@@ -164,12 +172,12 @@ impl<B: Backend> BlockMlp<B> {
 ///
 /// When `swa_enabled` is false, it simply applies the function `f` without any shift.
 ///
-/// ## Parameters
+/// # Arguments
 ///
-/// * `x` - Input tensor of shape (B, H, W, C).
+/// * `x` - Input tensor of ``[batch, height, width, channels]``.
 /// * `f` - Function to apply on the shifted tensor.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// A new tensor of the same shape as `x`, with the function `f` applied after cyclic shifting.
 #[must_use]
@@ -382,13 +390,13 @@ impl ShiftedWindowTransformerBlockConfig {
 
     /// Initializes a new `SwinTransformerBlock`.
     ///
-    /// # Parameters
+    /// # Arguments
     ///
     /// * `device` - The device on which the block will be created.
     ///
     /// # Returns
     ///
-    /// A new `SwinTransformerBlock` instance configured with the specified parameters.
+    /// A new `SwinTransformerBlock` configured with the specified parameters.
     #[must_use]
     pub fn init<B: Backend>(
         &self,
@@ -523,15 +531,17 @@ impl<B: Backend> ShiftedWindowTransformerBlockMeta for ShiftedWindowTransformerB
 impl<B: Backend> ShiftedWindowTransformerBlock<B> {
     /// Applies the forward pass on the input tensor.
     ///
-    /// H and W are the height and width of the input resolution, and D is the input dimension.
+    /// # Arguments
     ///
-    /// # Parameters
-    ///
-    /// * `x` - Input tensor of shape (B, H * W, D), where B is the batch size,
+    /// * `x` - Input tensor of ``[batch, height * width, channels]``.
     ///
     /// # Returns
     ///
-    /// A new tensor of shape (B, H * W, D) with the transformer block applied.
+    /// A new tensor of ``[batch, height * width, channels]``.
+    ///
+    /// # Panics
+    ///
+    /// On shape contract failure.
     #[must_use]
     pub fn forward(
         &self,
@@ -582,14 +592,14 @@ impl<B: Backend> ShiftedWindowTransformerBlock<B> {
     /// This function partitions the input tensor into windows, applies window attention,
     /// and then merges the windows back to the original shape.
     ///
-    /// ## Parameters
+    /// # Arguments
     ///
-    /// * `x` - Input tensor of shape (B, H, W, C).
+    /// * `x` - Input tensor of ``[batch, height, width, channels]``.
     /// * `c` - Number of channels in the input tensor.
     ///
-    /// ## Returns
+    /// # Returns
     ///
-    /// A new tensor of shape (B, H, W, C) with window attention applied.
+    /// A new tensor of ``[batch, height, width, channels]`` with window attention applied.
     #[must_use]
     #[inline(always)]
     fn apply_window(

--- a/crates/bimm/src/models/swin/v2/transformer.rs
+++ b/crates/bimm/src/models/swin/v2/transformer.rs
@@ -534,11 +534,15 @@ impl<B: Backend> SwinTransformerV2<B> {
     ///
     /// # Arguments
     ///
-    /// * `input`: A 4D tensor representing the input image with shape `[B, C, H, W]`,
+    /// * `input`: A tensor of ``[batch, channels, height, width]``,
     ///
     /// # Returns
     ///
-    /// A 2D tensor of shape `[B, num_classes]` representing the classification logits.
+    /// A 2D tensor of ``[batch, num_classes]`` of the classification logits.
+    ///
+    /// # Panics
+    ///
+    /// On shape contract failure.
     #[must_use]
     pub fn forward(
         &self,

--- a/crates/bimm/src/models/swin/v2/window_attention/attention_mask.rs
+++ b/crates/bimm/src/models/swin/v2/window_attention/attention_mask.rs
@@ -3,7 +3,7 @@ use burn::prelude::{Backend, Bool, Int, Tensor};
 
 /// Apply an attention mask.
 ///
-/// ## Parameters
+/// # Arguments
 ///
 /// - `b_nw`: Batch size times number of windows.
 /// - `n`: Number of elements in the input tensor, Wh*Ww.
@@ -11,7 +11,7 @@ use burn::prelude::{Backend, Bool, Int, Tensor};
 /// - `attn`: Attention logits tensor of shape (`b_nw`, `num_heads`, Wh*Ww, Wh*Ww).
 /// - `mask`: Mask tensor of shape (`num_windows`, Wh*Ww, Wh*Ww).
 ///
-/// ## Returns
+/// # Returns
 ///
 /// - Output tensor of shape (`b_nw`, `num_heads`, Wh*Ww, Wh*Ww).
 #[inline(always)]
@@ -43,14 +43,14 @@ pub fn apply_attention_mask<B: Backend>(
 ///
 /// This function generates a mask for the shifted window attention mechanism.
 ///
-/// ## Parameters
+/// # Arguments
 ///
 /// - `input_shape`: The shape of the input tensor; must be divisible by the window size.
 /// - `window_size`: The size of the window.
 /// - `shift_size`: The size of the shift.
 /// - `device`: The device on which the tensor will be created.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// A tensor representing the shifted window image mask.
 #[must_use]
@@ -111,14 +111,14 @@ fn sw_img_mask<B: Backend>(
 ///
 /// This function generates a mask for the shifted window attention mechanism.
 ///
-/// ## Parameters
+/// # Arguments
 ///
 /// - `input_shape`: The shape of the input tensor.
 /// - `window_size`: The size of the window.
 /// - `shift_size`: The size of the shift.
 /// - `device`: The device on which the tensor will be created.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// A tensor representing the shifted window attention mask.
 #[must_use]

--- a/crates/bimm/src/models/swin/v2/window_attention/pos_bias.rs
+++ b/crates/bimm/src/models/swin/v2/window_attention/pos_bias.rs
@@ -61,11 +61,11 @@ impl RelativePositionBiasMeta for RelativePositionBiasConfig {
 impl RelativePositionBiasConfig {
     /// Initializes an `OffsetGridRelativePositionBias` module.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
     /// * `device`: The device on which the module will be created.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// An `OffsetGridRelativePositionBias` module.
     #[inline(always)]
@@ -134,7 +134,7 @@ impl<B: Backend> OffsetGridRelativePositionBias<B> {
     /// This is hashed such that all pairs of locations in the window with the same
     /// inter-pair relative offset will have the same bias across all heads.
     ///
-    /// ## Returns
+    /// # Returns
     ///
     /// A 3D tensor of shape (`num_heads`, height * width, height * width)
     /// containing the relative position bias for each head and position
@@ -255,13 +255,13 @@ impl ContinuousPositionBiasMlpConfig {
 impl<B: Backend> ContinuousPositionBiasMlp<B> {
     /// Applies the MLP to the input tensor.
     ///
-    /// ## Arguments
+    /// # Arguments
     ///
-    /// * `x`: A tensor of ``(..., 2)`` of the relative log-offset coordinates table.
+    /// * `x`: A tensor of ``[..., 2]`` of the relative log-offset coordinates table.
     ///
-    /// ## Returns
+    /// # Returns
     ///
-    /// A tensor of ``(..., num_heads)`` of the learned bias table.
+    /// A tensor of ``[..., num_heads]`` of the learned bias table.
     #[must_use]
     pub fn forward<const D: usize>(
         &self,

--- a/crates/bimm/src/models/swin/v2/window_attention/pos_grid.rs
+++ b/crates/bimm/src/models/swin/v2/window_attention/pos_grid.rs
@@ -3,12 +3,12 @@ use burn::tensor::grid::{IndexPos, meshgrid_stack};
 
 /// Creates a grid of 2D offset indices for a given window shape.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// * `window_shape`: A (height, width) tuple describing the window shape.
 /// * `device`: The device on which the tensor will be created.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// A 3D tensor of shape (2*height-1, 2*width-1, 2) containing the offset indices.
 ///
@@ -40,12 +40,12 @@ pub fn window_index_offset_grid<B: Backend>(
 ///
 /// Converts `window_index_offset_grid` to ``.float()`` and scales by the maximum offset value.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// * `window_shape`: A (height, width) tuple describing the window shape.
 /// * `device`: The device on which the tensor will be created.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// A 3D tensor of shape (2*height-1, 2*width-1, 2) containing the relative offsets.
 #[inline(always)]
@@ -66,13 +66,13 @@ pub fn window_relative_offset_grid<B: Backend>(
 /// This is a variant of `window_relative_offset_grid` that applies a logarithmic transformation
 /// to the relative offsets.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// * `window_shape`: A (height, width) tuple describing the window shape.
 /// * `base`: The base for the logarithm.
 /// * `device`: The device on which the tensor will be created.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// A 3D tensor of shape (2*height-1, 2*width-1, 2) containing the log-scaled relative offsets.
 #[inline(always)]
@@ -92,12 +92,12 @@ pub fn window_log1p_relative_offset_grid<B: Backend>(
 
 /// Create a 2D attention bias relative position index for a given window shape.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// * `window_shape`: A (height, width) tuple describing the window shape.
 /// * `device`: The device on which the tensor will be created.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// A 2D tensor of shape (height * width, height * width) containing the relative position indices.
 ///
@@ -108,7 +108,7 @@ pub fn window_log1p_relative_offset_grid<B: Backend>(
 /// \forall i, j \in [0, h * w), \text{rel}[i, j] = \text{rel}[i + \Delta_i, j + \Delta_j]
 /// ```
 ///
-/// ## Example
+/// # Example
 ///
 /// ```rust.notest
 /// window_attention_relative_position_index([2, 3], device);

--- a/crates/bimm/src/models/swin/v2/windowing.rs
+++ b/crates/bimm/src/models/swin/v2/windowing.rs
@@ -6,13 +6,18 @@ use burn::tensor::BasicOps;
 
 /// Window Partition
 ///
-/// ## Parameters
+/// # Arguments
 ///
-/// - `tensor`: Input tensor of shape (B, H, W, C).
+/// - `tensor`: Input tensor of ``[batch, height, width, channels]``.
 /// - `window_size`: Window size.
 ///
-/// ## Returns
-///   - Output tensor of shape (B * `h_windows` * `w_windows`, `window_size`, `window_size`, C).
+/// # Returns
+///
+/// Output tensor of ``[batch * h_windows * w_windows, window_size, window_size, channels]``.
+///
+/// # Panics
+///
+/// On shape contract failure.
 #[inline]
 #[must_use]
 pub fn window_partition<B: Backend, K>(
@@ -42,27 +47,33 @@ where
 
 /// Window Reverse
 ///
-/// ## Parameters
-/// - `windows`: Input tensor of shape (B * `h_windows` * `w_windows`, `window_size`, `window_size`, C).
-/// - `window_size`: Window size.
-/// - `h`: Height of the original image.
-/// - `w`: Width of the original image.
+/// # Arguments
 ///
-/// ## Returns
-/// - Output tensor of shape (B, H, W, C).
+/// - `windows`: Input tensor of ``[batch * h_windows * w_windows, window_size, window_size, channels]``.
+/// - `window_size`: Window size.
+/// - `height`: Height of the original image.
+/// - `width`: Width of the original image.
+///
+/// # Returns
+///
+/// Output tensor of shape ``[batch, height, width, channels]``.
+///
+/// # Panics
+///
+/// On shape contract failure.
 #[inline]
 #[must_use]
 pub fn window_reverse<B: Backend, K>(
     windows: Tensor<B, 4, K>,
     window_size: usize,
-    h: usize,
-    w: usize,
+    height: usize,
+    width: usize,
 ) -> Tensor<B, 4, K>
 where
     K: BasicOps<B>,
 {
-    let h_wins = h / window_size;
-    let w_wins = w / window_size;
+    let h_wins = height / window_size;
+    let w_wins = width / window_size;
 
     let [b, c] = unpack_shape_contract!(
         [
@@ -83,7 +94,7 @@ where
     windows
         .reshape([b, h_wins, w_wins, window_size, window_size, c])
         .swap_dims(2, 3)
-        .reshape([b, h, w, c])
+        .reshape([b, height, width, c])
 }
 
 #[cfg(test)]

--- a/crates/bimm/src/utility/probability.rs
+++ b/crates/bimm/src/utility/probability.rs
@@ -6,11 +6,11 @@ use std::fmt::Debug;
 
 /// Validate a probability in the range ``[0.0, 1.0]``.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// - `prob`: the prob to check.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// An `anyhow::Result<prob>`
 #[inline]
@@ -23,15 +23,15 @@ pub fn try_probability<F: Float + Debug>(prob: F) -> anyhow::Result<F> {
 
 /// Expect a probability to be in range ``[0.0, 1.0]``, or panic.
 ///
-/// ## Arguments
+/// # Arguments
 ///
 /// - `prob`: the prob to check.
 ///
-/// ## Returns
+/// # Returns
 ///
 /// `prob`.
 ///
-/// ## Panics
+/// # Panics
 ///
 /// On range error.
 #[inline]


### PR DESCRIPTION
- Replace all occurrences of "## Arguments" and "## Returns" with "# Arguments" and "# Returns" for consistency.
- Apply changes across multiple modules, including `swin`, `burn`, `drop_block`, and others.
- Improve clarity and uniformity in documentation structure.