### PR TITLE
feat: add dynamic wrappers for `ModuleMapper` and `ModuleVisitor` in burn.

### DIFF
--- a/crates/bimm/src/utility/burn/mod.rs
+++ b/crates/bimm/src/utility/burn/mod.rs
@@ -2,5 +2,6 @@
 
 pub mod clamp;
 pub mod kernels;
+pub mod modwrapper;
 pub mod noise;
 pub mod shape;

--- a/crates/bimm/src/utility/burn/modwrapper/dyn_mapper.rs
+++ b/crates/bimm/src/utility/burn/modwrapper/dyn_mapper.rs
@@ -1,0 +1,427 @@
+//! # Burn [`ModuleMapper`] Dynamic Wrapper Support
+use burn::module::{ModuleMapper, ModuleVisitor, ParamId};
+use burn::prelude::Backend;
+use std::any::Any;
+use std::marker::PhantomData;
+
+/// Wraps a [`ModuleMapper`] as a [`DynModuleMapper`] for dynamic dispatch.
+///
+/// Supports tensor dims from 1 to 7.
+pub struct DynModuleMapperBridge<'a, B, M>
+where
+    B: Backend,
+    M: ModuleMapper<B>,
+{
+    inner: &'a mut M,
+    _phantom: PhantomData<B>,
+}
+
+impl<'a, B, M> DynModuleMapperBridge<'a, B, M>
+where
+    B: Backend,
+    M: ModuleMapper<B>,
+{
+    /// Create a new visitor bridge.
+    pub fn new(inner: &'a mut M) -> Self {
+        Self {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub trait DynModuleMapper<B: Backend> {
+    /// The dynamic equivalent for [`ModuleMapper::map_float`].
+    fn map_float_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: Box<dyn Any>,
+    ) -> Box<dyn Any>;
+
+    /// The dynamic equivalent for [`ModuleMapper::map_int`].
+    fn map_int_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: Box<dyn Any>,
+    ) -> Box<dyn Any>;
+
+    /// The dynamic equivalent for [`ModuleMapper::map_bool`].
+    fn map_bool_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: Box<dyn Any>,
+    ) -> Box<dyn Any>;
+}
+
+macro_rules! _impl_map_dims {
+    (
+        $self:ident,
+        $id:ident,
+        $tensor:ident,
+        $kind:ident,
+        $method:ident,
+        [ $($dim:literal),* ]) => {
+        $(
+            if let Some(t) = $tensor.downcast_ref::<Tensor<B, $dim, $kind>>() {
+              return Box::new($ self.inner.$method($id, t.clone()));
+            }
+        )*
+    };
+}
+
+impl<'a, B: Backend, M: ModuleMapper<B>> DynModuleMapper<B> for DynModuleMapperBridge<'a, B, M> {
+    fn map_float_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: Box<dyn Any>,
+    ) -> Box<dyn Any> {
+        use burn::prelude::{Float, Tensor};
+        _impl_map_dims!(self, id, tensor, Float, map_float, [1, 2, 3, 4, 5, 6, 7]);
+        panic!("Unsupported tensor type/dims");
+    }
+
+    fn map_int_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: Box<dyn Any>,
+    ) -> Box<dyn Any> {
+        use burn::prelude::{Int, Tensor};
+        _impl_map_dims!(self, id, tensor, Int, map_int, [1, 2, 3, 4, 5, 6, 7]);
+        panic!("Unsupported tensor type/dims");
+    }
+
+    fn map_bool_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: Box<dyn Any>,
+    ) -> Box<dyn Any> {
+        use burn::prelude::{Bool, Tensor};
+        _impl_map_dims!(self, id, tensor, Bool, map_bool, [1, 2, 3, 4, 5, 6, 7]);
+        panic!("Unsupported tensor type/dims");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utility;
+    use crate::utility::burn::modwrapper::dyn_visitor::{DynModuleVisitor, DynModuleVisitorBridge};
+    use burn::backend::NdArray;
+    use burn::backend::ndarray::NdArrayDevice;
+    use burn::prelude::{Bool, Float, Int, Shape, Tensor};
+
+    #[derive(Debug, PartialEq)]
+    pub struct VisitRecord {
+        pub id: ParamId,
+        pub shape: Shape,
+    }
+    impl VisitRecord {
+        pub fn new(
+            id: ParamId,
+            shape: Shape,
+        ) -> Self {
+            Self { id, shape }
+        }
+    }
+
+    pub struct TestMapper {
+        floats: Vec<VisitRecord>,
+        ints: Vec<VisitRecord>,
+        bools: Vec<VisitRecord>,
+    }
+    impl TestMapper {
+        fn new() -> Self {
+            Self {
+                floats: Vec::new(),
+                ints: Vec::new(),
+                bools: Vec::new(),
+            }
+        }
+    }
+
+    impl<B: Backend> ModuleMapper<B> for TestMapper {
+        fn map_float<const D: usize>(
+            &mut self,
+            id: ParamId,
+            tensor: Tensor<B, D>,
+        ) -> Tensor<B, D> {
+            self.floats.push(VisitRecord::new(id, tensor.shape()));
+            tensor
+        }
+
+        fn map_int<const D: usize>(
+            &mut self,
+            id: ParamId,
+            tensor: Tensor<B, D, Int>,
+        ) -> Tensor<B, D, Int> {
+            self.ints.push(VisitRecord::new(id, tensor.shape()));
+            tensor
+        }
+
+        fn map_bool<const D: usize>(
+            &mut self,
+            id: ParamId,
+            tensor: Tensor<B, D, Bool>,
+        ) -> Tensor<B, D, Bool> {
+            self.bools.push(VisitRecord::new(id, tensor.shape()));
+            tensor
+        }
+    }
+
+    #[test]
+    fn test_mapper_bridge() {
+        type B = NdArray;
+        let device = NdArrayDevice::default();
+
+        let mut mapper = TestMapper::new();
+        let mut bridge: DynModuleMapperBridge<B, TestMapper> =
+            DynModuleMapperBridge::new(&mut mapper);
+
+        let tensor: Tensor<B, 1, Float> = Tensor::empty([1], &device);
+        let result = bridge.map_float_dyn(ParamId::from(101), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 1, Float>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 2, Float> = Tensor::empty([1, 1], &device);
+        let result = bridge.map_float_dyn(ParamId::from(102), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 2, Float>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 3, Float> = Tensor::empty([1, 1, 1], &device);
+        let result = bridge.map_float_dyn(ParamId::from(103), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 3, Float>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 4, Float> = Tensor::empty([1, 1, 1, 1], &device);
+        let result = bridge.map_float_dyn(ParamId::from(104), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 4, Float>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 5, Float> = Tensor::empty([1, 1, 1, 1, 1], &device);
+        let result = bridge.map_float_dyn(ParamId::from(105), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 5, Float>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 6, Float> = Tensor::empty([1, 1, 1, 1, 1, 1], &device);
+        let result = bridge.map_float_dyn(ParamId::from(106), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 6, Float>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 7, Float> = Tensor::empty([1, 1, 1, 1, 1, 1, 1], &device);
+        let result = bridge.map_float_dyn(ParamId::from(107), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 7, Float>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 1, Int> = Tensor::empty([1], &device);
+        let result = bridge.map_int_dyn(ParamId::from(201), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 1, Int>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 2, Int> = Tensor::empty([1, 1], &device);
+        let result = bridge.map_int_dyn(ParamId::from(202), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 2, Int>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 3, Int> = Tensor::empty([1, 1, 1], &device);
+        let result = bridge.map_int_dyn(ParamId::from(203), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 3, Int>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 4, Int> = Tensor::empty([1, 1, 1, 1], &device);
+        let result = bridge.map_int_dyn(ParamId::from(204), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 4, Int>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 5, Int> = Tensor::empty([1, 1, 1, 1, 1], &device);
+        let result = bridge.map_int_dyn(ParamId::from(205), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 5, Int>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 6, Int> = Tensor::empty([1, 1, 1, 1, 1, 1], &device);
+        let result = bridge.map_int_dyn(ParamId::from(206), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 6, Int>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 7, Int> = Tensor::empty([1, 1, 1, 1, 1, 1, 1], &device);
+        let result = bridge.map_int_dyn(ParamId::from(207), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 7, Int>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 1, Bool> = Tensor::empty([1], &device);
+        let result = bridge.map_bool_dyn(ParamId::from(301), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 1, Bool>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 2, Bool> = Tensor::empty([1, 1], &device);
+        let result = bridge.map_bool_dyn(ParamId::from(302), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 2, Bool>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 3, Bool> = Tensor::empty([1, 1, 1], &device);
+        let result = bridge.map_bool_dyn(ParamId::from(303), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 3, Bool>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 4, Bool> = Tensor::empty([1, 1, 1, 1], &device);
+        let result = bridge.map_bool_dyn(ParamId::from(304), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 4, Bool>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 5, Bool> = Tensor::empty([1, 1, 1, 1, 1], &device);
+        let result = bridge.map_bool_dyn(ParamId::from(305), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 5, Bool>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 6, Bool> = Tensor::empty([1, 1, 1, 1, 1, 1], &device);
+        let result = bridge.map_bool_dyn(ParamId::from(306), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 6, Bool>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        let tensor: Tensor<B, 7, Bool> = Tensor::empty([1, 1, 1, 1, 1, 1, 1], &device);
+        let result = bridge.map_bool_dyn(ParamId::from(307), Box::new(tensor.clone()));
+        result
+            .downcast_ref::<Tensor<B, 7, Bool>>()
+            .unwrap()
+            .to_data()
+            .assert_eq(&tensor.to_data(), true);
+
+        assert_eq!(
+            &mapper.floats,
+            &vec![
+                VisitRecord::new(ParamId::from(101), Shape::from([1])),
+                VisitRecord::new(ParamId::from(102), Shape::from([1, 1])),
+                VisitRecord::new(ParamId::from(103), Shape::from([1, 1, 1])),
+                VisitRecord::new(ParamId::from(104), Shape::from([1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(105), Shape::from([1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(106), Shape::from([1, 1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(107), Shape::from([1, 1, 1, 1, 1, 1, 1])),
+            ],
+        );
+        assert_eq!(
+            &mapper.ints,
+            &vec![
+                VisitRecord::new(ParamId::from(201), Shape::from([1])),
+                VisitRecord::new(ParamId::from(202), Shape::from([1, 1])),
+                VisitRecord::new(ParamId::from(203), Shape::from([1, 1, 1])),
+                VisitRecord::new(ParamId::from(204), Shape::from([1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(205), Shape::from([1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(206), Shape::from([1, 1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(207), Shape::from([1, 1, 1, 1, 1, 1, 1])),
+            ],
+        );
+        assert_eq!(
+            &mapper.bools,
+            &vec![
+                VisitRecord::new(ParamId::from(301), Shape::from([1])),
+                VisitRecord::new(ParamId::from(302), Shape::from([1, 1])),
+                VisitRecord::new(ParamId::from(303), Shape::from([1, 1, 1])),
+                VisitRecord::new(ParamId::from(304), Shape::from([1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(305), Shape::from([1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(306), Shape::from([1, 1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(307), Shape::from([1, 1, 1, 1, 1, 1, 1])),
+            ],
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported tensor type/dims")]
+    fn test_mapper_float_too_many_dims() {
+        type B = NdArray;
+        let device = NdArrayDevice::default();
+
+        let mut mapper = TestMapper::new();
+        let mut bridge: DynModuleMapperBridge<B, TestMapper> =
+            DynModuleMapperBridge::new(&mut mapper);
+
+        let t: Tensor<B, 8> = Tensor::empty([1, 1, 1, 1, 1, 1, 1, 1], &device);
+        let _t = bridge.map_float_dyn(ParamId::from(1), Box::new(t));
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported tensor type/dims")]
+    fn test_mapper_int_too_many_dims() {
+        type B = NdArray;
+        let device = NdArrayDevice::default();
+
+        let mut mapper = TestMapper::new();
+        let mut bridge: DynModuleMapperBridge<B, TestMapper> =
+            DynModuleMapperBridge::new(&mut mapper);
+
+        let t: Tensor<B, 8, Int> = Tensor::empty([1, 1, 1, 1, 1, 1, 1, 1], &device);
+        let _t = bridge.map_int_dyn(ParamId::from(1), Box::new(t));
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported tensor type/dims")]
+    fn test_mapper_bool_too_many_dims() {
+        type B = NdArray;
+        let device = NdArrayDevice::default();
+
+        let mut mapper = TestMapper::new();
+        let mut bridge: DynModuleMapperBridge<B, TestMapper> =
+            DynModuleMapperBridge::new(&mut mapper);
+
+        let t: Tensor<B, 8, Bool> = Tensor::empty([1, 1, 1, 1, 1, 1, 1, 1], &device);
+        let _t = bridge.map_bool_dyn(ParamId::from(1), Box::new(t));
+    }
+}

--- a/crates/bimm/src/utility/burn/modwrapper/dyn_visitor.rs
+++ b/crates/bimm/src/utility/burn/modwrapper/dyn_visitor.rs
@@ -1,0 +1,336 @@
+//! # Burn [`ModuleVisitor`] Dynamic Wrapper Support
+
+use burn::module::{ModuleMapper, ModuleVisitor, ParamId};
+use burn::prelude::{Backend, Tensor};
+use std::any::Any;
+use std::marker::PhantomData;
+
+/// Wraps a [`ModuleVisitor`] as a [`DynModuleVisitor`] for dynamic dispatch.
+///
+/// Supports tensor dims from 1 to 7.
+pub struct DynModuleVisitorBridge<'a, B, V>
+where
+    B: Backend,
+    V: ModuleVisitor<B>,
+{
+    inner: &'a mut V,
+    _phantom: PhantomData<B>,
+}
+impl<'a, B, V> DynModuleVisitorBridge<'a, B, V>
+where
+    B: Backend,
+    V: ModuleVisitor<B>,
+{
+    /// Create a new visitor bridge.
+    pub fn new(inner: &'a mut V) -> Self {
+        Self {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// The dynamic dispatch trait for [`ModuleVisitor`].
+pub trait DynModuleVisitor<B: Backend> {
+    /// The dynamic equivalent for [`ModuleVisitor::visit_float`].
+    fn visit_float_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: &dyn Any,
+    );
+
+    /// The dynamic equivalent for [`ModuleVisitor::visit_int`].
+    fn visit_int_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: &dyn Any,
+    );
+
+    /// The dynamic equivalent for [`ModuleVisitor::visit_bool`].
+    fn visit_bool_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: &dyn Any,
+    );
+}
+
+macro_rules! _impl_visit_dims {
+    (
+        $self:ident,
+        $id:ident,
+        $tensor:ident,
+        $kind:ident,
+        $method:ident,
+        [ $($dim:literal),* ]
+    ) => {
+        $(
+            if let Some(t) = $tensor.downcast_ref::<Tensor<B, $dim, $kind>>() {
+                $self.inner.$method($id, t);
+                return
+            }
+        )*
+    };
+}
+impl<'a, B: Backend, V: ModuleVisitor<B>> DynModuleVisitor<B> for DynModuleVisitorBridge<'a, B, V> {
+    fn visit_float_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: &dyn Any,
+    ) {
+        use burn::prelude::{Float, Tensor};
+        _impl_visit_dims!(self, id, tensor, Float, visit_float, [1, 2, 3, 4, 5, 6, 7]);
+        panic!("Unsupported tensor type/dims");
+    }
+
+    fn visit_int_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: &dyn Any,
+    ) {
+        use burn::prelude::{Int, Tensor};
+        _impl_visit_dims!(self, id, tensor, Int, visit_int, [1, 2, 3, 4, 5, 6, 7]);
+        panic!("Unsupported tensor type/dims");
+    }
+
+    fn visit_bool_dyn(
+        &mut self,
+        id: ParamId,
+        tensor: &dyn Any,
+    ) {
+        use burn::prelude::{Bool, Tensor};
+        _impl_visit_dims!(self, id, tensor, Bool, visit_bool, [1, 2, 3, 4, 5, 6, 7]);
+        panic!("Unsupported tensor type/dims");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use burn::backend::NdArray;
+    use burn::backend::ndarray::NdArrayDevice;
+    use burn::prelude::{Bool, Float, Int, Shape, Tensor};
+
+    #[derive(Debug, PartialEq)]
+    pub struct VisitRecord {
+        pub id: ParamId,
+        pub shape: Shape,
+    }
+    impl VisitRecord {
+        pub fn new(
+            id: ParamId,
+            shape: Shape,
+        ) -> Self {
+            Self { id, shape }
+        }
+    }
+
+    pub struct TestVisitor {
+        floats: Vec<VisitRecord>,
+        ints: Vec<VisitRecord>,
+        bools: Vec<VisitRecord>,
+    }
+    impl TestVisitor {
+        pub fn new() -> Self {
+            Self {
+                floats: Vec::new(),
+                ints: Vec::new(),
+                bools: Vec::new(),
+            }
+        }
+    }
+    impl<B: Backend> ModuleVisitor<B> for TestVisitor {
+        fn visit_float<const D: usize>(
+            &mut self,
+            id: ParamId,
+            tensor: &Tensor<B, D>,
+        ) {
+            self.floats.push(VisitRecord::new(id, tensor.shape()))
+        }
+        fn visit_int<const D: usize>(
+            &mut self,
+            id: ParamId,
+            tensor: &Tensor<B, D, Int>,
+        ) {
+            self.ints.push(VisitRecord::new(id, tensor.shape()))
+        }
+        fn visit_bool<const D: usize>(
+            &mut self,
+            id: ParamId,
+            tensor: &Tensor<B, D, Bool>,
+        ) {
+            self.bools.push(VisitRecord::new(id, tensor.shape()))
+        }
+    }
+
+    #[test]
+    fn test_visitor_bridge() {
+        type B = NdArray;
+        let device = NdArrayDevice::default();
+
+        let mut visitor = TestVisitor::new();
+        let mut bridge = DynModuleVisitorBridge::<B, TestVisitor>::new(&mut visitor);
+
+        bridge.visit_float_dyn(
+            ParamId::from(101),
+            &Tensor::<B, 1, Float>::empty([1], &device),
+        );
+        bridge.visit_float_dyn(
+            ParamId::from(102),
+            &Tensor::<B, 2, Float>::empty([1, 1], &device),
+        );
+        bridge.visit_float_dyn(
+            ParamId::from(103),
+            &Tensor::<B, 3, Float>::empty([1, 1, 1], &device),
+        );
+        bridge.visit_float_dyn(
+            ParamId::from(104),
+            &Tensor::<B, 4, Float>::empty([1, 1, 1, 1], &device),
+        );
+        bridge.visit_float_dyn(
+            ParamId::from(105),
+            &Tensor::<B, 5, Float>::empty([1, 1, 1, 1, 1], &device),
+        );
+        bridge.visit_float_dyn(
+            ParamId::from(106),
+            &Tensor::<B, 6, Float>::empty([1, 1, 1, 1, 1, 1], &device),
+        );
+        bridge.visit_float_dyn(
+            ParamId::from(107),
+            &Tensor::<B, 7, Float>::empty([1, 1, 1, 1, 1, 1, 1], &device),
+        );
+
+        bridge.visit_int_dyn(
+            ParamId::from(201),
+            &Tensor::<B, 1, Int>::empty([1], &device),
+        );
+        bridge.visit_int_dyn(
+            ParamId::from(202),
+            &Tensor::<B, 2, Int>::empty([1, 1], &device),
+        );
+        bridge.visit_int_dyn(
+            ParamId::from(203),
+            &Tensor::<B, 3, Int>::empty([1, 1, 1], &device),
+        );
+        bridge.visit_int_dyn(
+            ParamId::from(204),
+            &Tensor::<B, 4, Int>::empty([1, 1, 1, 1], &device),
+        );
+        bridge.visit_int_dyn(
+            ParamId::from(205),
+            &Tensor::<B, 5, Int>::empty([1, 1, 1, 1, 1], &device),
+        );
+        bridge.visit_int_dyn(
+            ParamId::from(206),
+            &Tensor::<B, 6, Int>::empty([1, 1, 1, 1, 1, 1], &device),
+        );
+        bridge.visit_int_dyn(
+            ParamId::from(207),
+            &Tensor::<B, 7, Int>::empty([1, 1, 1, 1, 1, 1, 1], &device),
+        );
+
+        bridge.visit_bool_dyn(
+            ParamId::from(301),
+            &Tensor::<B, 1, Bool>::empty([1], &device),
+        );
+        bridge.visit_bool_dyn(
+            ParamId::from(302),
+            &Tensor::<B, 2, Bool>::empty([1, 1], &device),
+        );
+        bridge.visit_bool_dyn(
+            ParamId::from(303),
+            &Tensor::<B, 3, Bool>::empty([1, 1, 1], &device),
+        );
+        bridge.visit_bool_dyn(
+            ParamId::from(304),
+            &Tensor::<B, 4, Bool>::empty([1, 1, 1, 1], &device),
+        );
+        bridge.visit_bool_dyn(
+            ParamId::from(305),
+            &Tensor::<B, 5, Bool>::empty([1, 1, 1, 1, 1], &device),
+        );
+        bridge.visit_bool_dyn(
+            ParamId::from(306),
+            &Tensor::<B, 6, Bool>::empty([1, 1, 1, 1, 1, 1], &device),
+        );
+        bridge.visit_bool_dyn(
+            ParamId::from(307),
+            &Tensor::<B, 7, Bool>::empty([1, 1, 1, 1, 1, 1, 1], &device),
+        );
+
+        assert_eq!(
+            &visitor.floats,
+            &vec![
+                VisitRecord::new(ParamId::from(101), Shape::from([1])),
+                VisitRecord::new(ParamId::from(102), Shape::from([1, 1])),
+                VisitRecord::new(ParamId::from(103), Shape::from([1, 1, 1])),
+                VisitRecord::new(ParamId::from(104), Shape::from([1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(105), Shape::from([1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(106), Shape::from([1, 1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(107), Shape::from([1, 1, 1, 1, 1, 1, 1])),
+            ],
+        );
+        assert_eq!(
+            &visitor.ints,
+            &vec![
+                VisitRecord::new(ParamId::from(201), Shape::from([1])),
+                VisitRecord::new(ParamId::from(202), Shape::from([1, 1])),
+                VisitRecord::new(ParamId::from(203), Shape::from([1, 1, 1])),
+                VisitRecord::new(ParamId::from(204), Shape::from([1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(205), Shape::from([1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(206), Shape::from([1, 1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(207), Shape::from([1, 1, 1, 1, 1, 1, 1])),
+            ],
+        );
+        assert_eq!(
+            &visitor.bools,
+            &vec![
+                VisitRecord::new(ParamId::from(301), Shape::from([1])),
+                VisitRecord::new(ParamId::from(302), Shape::from([1, 1])),
+                VisitRecord::new(ParamId::from(303), Shape::from([1, 1, 1])),
+                VisitRecord::new(ParamId::from(304), Shape::from([1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(305), Shape::from([1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(306), Shape::from([1, 1, 1, 1, 1, 1])),
+                VisitRecord::new(ParamId::from(307), Shape::from([1, 1, 1, 1, 1, 1, 1])),
+            ],
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported tensor type/dims")]
+    fn test_visitor_float_too_many_dims() {
+        type B = NdArray;
+        let device = NdArrayDevice::default();
+
+        let mut visitor = TestVisitor::new();
+        let mut bridge = DynModuleVisitorBridge::<B, TestVisitor>::new(&mut visitor);
+
+        let t: Tensor<B, 8> = Tensor::empty([1, 1, 1, 1, 1, 1, 1, 1], &device);
+        bridge.visit_float_dyn(ParamId::from(1), &t);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported tensor type/dims")]
+    fn test_visitor_int_too_many_dims() {
+        type B = NdArray;
+        let device = NdArrayDevice::default();
+
+        let mut visitor = TestVisitor::new();
+        let mut bridge = DynModuleVisitorBridge::<B, TestVisitor>::new(&mut visitor);
+
+        let t: Tensor<B, 8, Int> = Tensor::empty([1, 1, 1, 1, 1, 1, 1, 1], &device);
+        bridge.visit_int_dyn(ParamId::from(1), &t);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported tensor type/dims")]
+    fn test_visitor_bool_too_many_dims() {
+        type B = NdArray;
+        let device = NdArrayDevice::default();
+
+        let mut visitor = TestVisitor::new();
+        let mut bridge = DynModuleVisitorBridge::<B, TestVisitor>::new(&mut visitor);
+
+        let t: Tensor<B, 8, Bool> = Tensor::empty([1, 1, 1, 1, 1, 1, 1, 1], &device);
+        bridge.visit_bool_dyn(ParamId::from(1), &t);
+    }
+}

--- a/crates/bimm/src/utility/burn/modwrapper/mod.rs
+++ b/crates/bimm/src/utility/burn/modwrapper/mod.rs
@@ -1,0 +1,68 @@
+//! # Module Wrapper
+
+use burn::module::{Module, ModuleMapper, ModuleVisitor};
+use burn::prelude::Backend;
+use burn::record::{PrecisionSettings, Record};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use std::any::Any;
+
+pub mod dyn_mapper;
+pub mod dyn_visitor;
+/*
+trait DynModuleInner<B: Backend>: Send {
+    fn clone_box(&self) -> Box<dyn DynModuleInner<B>>;
+    fn fork_box(self: Box<Self>, device: &B::Device) -> Box<dyn DynModuleInner<B>>;
+    fn to_device_box(self: Box<Self>, device: &B::Device) -> Box<dyn DynModuleInner<B>>;
+    fn no_grad_box(self: Box<Self>) -> Box<dyn DynModuleInner<B>>;
+    fn map_box<Mapper: ModuleMapper<B>>(self: Box<Self>, mapper: &mut Mapper) -> Box<dyn DynModuleInner<B>>;
+
+    fn num_params(&self) -> usize;
+    fn collect_devices(&self, devices: Devices<B>) -> Devices<B>;
+    fn visit<Visitor: ModuleVisitor<B>>(self: Box<Self>, visitor: &mut Visitor);
+}
+
+// Blanket implementation
+impl<B: Backend, M> DynModuleInner<B> for M
+where
+    M: Module<B> + Clone + Send + 'static
+{
+    fn clone_box(&self) -> Box<dyn DynModuleInner<B>> {
+        Box::new(self.clone())
+    }
+
+    fn collect_devices(&self, devices: Devices<B>) -> Devices<B> {
+        self.collect_devices(devices)
+    }
+
+    fn fork_box(self: Box<Self>, device: &B::Device) -> Box<dyn DynModuleInner<B>> {
+        // Unbox, fork (consuming), and rebox
+        Box::new((*self).fork(device))
+    }
+
+    fn to_device_box(self: Box<Self>, device: &B::Device) -> Box<dyn DynModuleInner<B>> {
+        Box::new((*self).to_device(device))
+    }
+
+    fn no_grad_box(self: Box<Self>) -> Box<dyn DynModuleInner<B>> {
+        Box::new((*self).no_grad())
+    }
+
+    fn num_params(&self) -> usize {
+        self.num_params()
+    }
+}
+
+pub trait ForwardTtoT {
+    fn forward<B: Backend, const D: usize>(
+        &self,
+        x: Tensor<B, D>
+    ) -> Tensor<B, D>;
+}
+ */
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_dyn_module_inner() {}
+}


### PR DESCRIPTION
- Introduced `DynModuleMapper` and `DynModuleVisitor` bridges for dynamic dispatch.
- Added new submodules (`modwrapper`, `dyn_mapper`, `dyn_visitor`) under `burn`.
- Implemented tests for supported tensor dimensions (1-7) and edge cases for both mappers and visitors.
- Expanded `burn` utility structure with enhanced modularity.