### PR TITLE
feat: integrate configurable activation functions and RPB MLP support

### DIFF
--- a/.run/Test.run.xml
+++ b/.run/Test.run.xml
@@ -16,9 +16,9 @@
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2">
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Fix" run_configuration_type="CargoCommandRunConfiguration" />
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="Format" run_configuration_type="CargoCommandRunConfiguration" />
       <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Fix" run_configuration_type="CargoCommandRunConfiguration" />
     </method>
   </configuration>
 </component>

--- a/crates/bimm/src/layers/activation/activation_layer.rs
+++ b/crates/bimm/src/layers/activation/activation_layer.rs
@@ -37,6 +37,12 @@ pub enum ActivationLayerConfig {
     Linear(LinearConfig),
 }
 
+impl Default for ActivationLayerConfig {
+    fn default() -> Self {
+        Self::Relu
+    }
+}
+
 impl ActivationLayerConfig {
     /// Initialize a wrapped activation layer.
     pub fn init<B: Backend>(

--- a/crates/bimm/src/models/swin/v2/window_attention/mod.rs
+++ b/crates/bimm/src/models/swin/v2/window_attention/mod.rs
@@ -6,6 +6,7 @@ pub use attention_mask::*;
 pub use pos_bias::*;
 pub use pos_grid::*;
 
+use crate::layers::activation::ActivationLayerConfig;
 use bimm_contracts::{assert_shape_contract_periodically, unpack_shape_contract};
 use burn::config::Config;
 use burn::module::{Module, Param, ParamId};
@@ -71,6 +72,14 @@ pub struct WindowAttentionConfig {
     /// Dropout rate for projection.
     #[config(default = 0.)]
     pub proj_drop: f64,
+
+    /// The hidden dimension of the MLP.
+    #[config(default = 512)]
+    pub rpb_mlp_hidden_dim: usize,
+
+    /// The activation layer configuration.
+    #[config(default = "ActivationLayerConfig::Relu")]
+    pub rpb_mlp_activation: ActivationLayerConfig,
 }
 
 impl WindowAttentionMeta for WindowAttentionConfig {
@@ -366,6 +375,8 @@ impl WindowAttentionConfig {
             }
             .init(),
             rpb_module: RelativePositionBiasConfig::new(num_heads, window_size)
+                .with_mlp_hidden_dim(self.rpb_mlp_hidden_dim)
+                .with_mlp_activation(self.rpb_mlp_activation.clone())
                 .init_offset_grid_rpb(device),
             proj: LinearConfig::new(d_input, d_input)
                 .with_bias(false)


### PR DESCRIPTION
- Replaced hardcoded `Gelu` with `ActivationLayer` across modules for greater flexibility.
- Enhanced support for MLPs in relative position bias (RPB) with dynamic hidden dimension and activation function configurations.
- Added default values and simplified initialization for activation layers and related configurations.