### PR TITLE
feat: enhance `DropBlock2d` with new options and benchmarking support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +317,7 @@ dependencies = [
  "anyhow",
  "bimm-contracts",
  "burn",
+ "criterion",
  "hamcrest",
  "num-traits",
  "serde",
@@ -920,6 +927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +973,33 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "cipher"
@@ -1128,6 +1168,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex 1.11.1",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -3773,6 +3846,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3874,6 +3953,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "png"
@@ -5333,6 +5440,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@
 resolver = "2"
 
 members = [
-  "crates/*",
-  "examples/*",
+    "crates/*",
+    "examples/*",
 ]
 
 [workspace.package]
@@ -30,16 +30,16 @@ doc_markdown = "warn"
 [workspace.dependencies]
 burn = { version = "^0.18.0" }
 
-bimm-contracts = { version = "^0.4.1"}
+bimm-contracts = { version = "^0.4.1" }
 
 # Burn coupled-dependencies
 globwalk = { version = "^0.9.1" }
 serde = { version = "^1.0.219" }
 serde_json = { version = "^1.0.143" }
 
-clap = { version = "^4.5.45"}
+clap = { version = "^4.5.45" }
 
-rand = {  version = "^0.9.2"  }
+rand = { version = "^0.9.2" }
 regex = { version = "^1.11.1" }
 regex-macro = { version = "^0.3.0" }
 anyhow = { version = "^1.0.99" }
@@ -50,7 +50,7 @@ image = { version = "^0.25.6" }
 inventory = { version = "^0.3.20" }
 
 # Test and/or Examples dependencies
-# criterion = { version = "^0.7.0" }
+criterion = { version = "^0.7.0" }
 hamcrest = { version = "^0.1.5" }
 image-compare = { version = "^0.5.0" }
 indoc = { version = "^2.0.6" }

--- a/crates/bimm/Cargo.toml
+++ b/crates/bimm/Cargo.toml
@@ -12,7 +12,7 @@ description = "burn image models"
 workspace = true
 
 [dependencies]
-bimm-contracts = { workspace = true, features = ["burn"]}
+bimm-contracts = { workspace = true, features = ["burn"] }
 
 burn = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -22,6 +22,7 @@ num-traits = { workspace = true }
 
 [dev-dependencies]
 burn = { workspace = true, features = ["autodiff", "ndarray"] }
+criterion = { workspace = true }
 
 num-traits = { workspace = true }
 hamcrest = { workspace = true }
@@ -30,3 +31,6 @@ hamcrest = { workspace = true }
 default = []
 std = []
 
+[[bench]]
+name = "drop_block"
+harness = false

--- a/crates/bimm/benches/drop_block.rs
+++ b/crates/bimm/benches/drop_block.rs
@@ -1,0 +1,50 @@
+use bimm::layers::drop::drop_block::{DropBlockOptions, drop_block_2d};
+use bimm::utility::burn::noise::NoiseConfig;
+use burn::backend::NdArray;
+use burn::prelude::Tensor;
+use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+fn bench_drop_block_10x32x32x3_7_normalise(c: &mut Criterion) {
+    type B = NdArray<f32>;
+    let device = Default::default();
+
+    let batch_size = 10;
+    let height = 32;
+    let width = height;
+    let channels = 3;
+
+    let shape = [batch_size, height, width, channels];
+    let tensor: Tensor<B, 4> = Tensor::ones(shape, &device);
+
+    for noise in [None, Some(NoiseConfig::default())] {
+        for batchwise in [false, true] {
+            for couple_channels in [false, true] {
+                for partial_edge_blocks in [false, true] {
+                    let config = DropBlockOptions::default()
+                        .with_batchwise(batchwise)
+                        .with_couple_channels(couple_channels)
+                        .with_partial_edge_blocks(partial_edge_blocks)
+                        .with_noise(noise.clone());
+
+                    c.bench_function(
+                        format!(
+                            "drop_block_2d: {:?} norm noise={} b={batchwise} c={couple_channels} p={partial_edge_blocks}",
+                            shape,
+                            noise.is_some(),
+                        )
+                            .as_str(),
+                        |b| {
+                            b.iter(|| {
+                                black_box(drop_block_2d(tensor.clone(), &config));
+                            })
+                        },
+                    );
+                }
+            }
+        }
+    }
+}
+
+criterion_group!(benches, bench_drop_block_10x32x32x3_7_normalise,);
+criterion_main!(benches);


### PR DESCRIPTION
- Added `couple_channels` and `batchwise` options in `DropBlockOptions` for more flexible noise configurations.
- Introduced `criterion` dependency and added a new benchmark for `drop_block_2d`.
- Updated related tests to cover new configurations and adjusted tensor shapes for performance validation.
- Improved documentation for `DropBlockOptions` with detailed descriptions of new parameters.